### PR TITLE
Add cache control to Cursor Tab messages

### DIFF
--- a/src/app/[...openai]/route.ts
+++ b/src/app/[...openai]/route.ts
@@ -111,14 +111,25 @@ export async function POST(
       });
     }
 
+    const streamTextOptions = {
+      model: aiModel,
+      messages: modifiedMessages,
+      maxTokens: ["anthropic", "anthropiccached"].includes(
+        provider.toLowerCase(),
+      )
+        ? 8192
+        : undefined,
+      // Add other parameters from defaultConfig if needed
+    };
+
     const logEntry = {
       method: "POST",
       url: `/api/${endpoint}`,
       headers: JSON.stringify(Object.fromEntries(request.headers)),
       body: JSON.stringify({
         ...body,
-        messages: modifiedMessages,
-        model: model,
+        ...streamTextOptions,
+        model: model, // Use the model from defaultConfig
       }),
       response: "",
       timestamp: new Date(),
@@ -136,13 +147,7 @@ export async function POST(
 
     if (stream) {
       const result = await streamText({
-        model: aiModel,
-        messages: modifiedMessages,
-        maxTokens: ["anthropic", "anthropiccached"].includes(
-          provider.toLowerCase(),
-        )
-          ? 8192
-          : undefined,
+        ...streamTextOptions,
         async onFinish({
           text,
           toolCalls,

--- a/src/app/[...openai]/route.ts
+++ b/src/app/[...openai]/route.ts
@@ -138,7 +138,11 @@ export async function POST(
       const result = await streamText({
         model: aiModel,
         messages: modifiedMessages,
-        maxTokens: provider === "anthropic" ? 8192 : undefined,
+        maxTokens: ["anthropic", "anthropiccached"].includes(
+          provider.toLowerCase(),
+        )
+          ? 8192
+          : undefined,
         async onFinish({
           text,
           toolCalls,

--- a/src/app/[...openai]/route.ts
+++ b/src/app/[...openai]/route.ts
@@ -98,6 +98,10 @@ export async function POST(
     let modifiedMessages = messages;
 
     if (provider.toLowerCase() === "anthropiccached") {
+      const hasPotentialContext = messages.some(
+        (message: any) => message.name === "potential_context",
+      );
+
       modifiedMessages = messages.map((message: any) => {
         if (message.name === "potential_context") {
           return {
@@ -109,6 +113,15 @@ export async function POST(
         }
         return message;
       });
+
+      if (!hasPotentialContext && modifiedMessages.length >= 2) {
+        modifiedMessages[1] = {
+          ...modifiedMessages[1],
+          experimental_providerMetadata: {
+            anthropic: { cacheControl: { type: "ephemeral" } },
+          },
+        };
+      }
     }
 
     const streamTextOptions = {


### PR DESCRIPTION
Cursor Tab doesn't use `potential_context`, adding it to the second user message instead. 